### PR TITLE
Update SW_conversion.cfg

### DIFF
--- a/Switchwire Magprobe/config/SW_conversion.cfg
+++ b/Switchwire Magprobe/config/SW_conversion.cfg
@@ -66,6 +66,6 @@ gcode:
     #Check location at z25 and edit
     G1 X229 Z10 F3000 #probe location
     G4 P300
-    G1 X230 Z10 F3000 #undock
+    G1 X240 Z10 F3000 #undock
     SERVO_IN
     G1 X125 Z10 F3000 #undock


### PR DESCRIPTION
Edit Line 69 undock movement.
There was some case where the probe was failed to be stored.
(The reason may be that the magnetism of the storage part is weak, but it has been modified for safe storage.)