### PR TITLE
Update SW_conversion.cfg

### DIFF
--- a/Switchwire Magprobe/config/SW_conversion.cfg
+++ b/Switchwire Magprobe/config/SW_conversion.cfg
@@ -63,9 +63,7 @@ gcode:
     G1 X206 Z10F4000
     SERVO_OUT
     G4 P400
-    #Check location at z25 and edit
-    G1 X229 Z10 F3000 #probe location
+    G1 X245 Z10 F3000 #undock
     G4 P300
-    G1 X230 Z10 F3000 #undock
     SERVO_IN
     G1 X125 Z10 F3000 #undock


### PR DESCRIPTION
Edit  undock movement.
There was some case where the probe was failed to be stored.
(It is suspected that the magnetism is weak or that the magnetic force is temporarily weakened due to the high temperature heat bed.)